### PR TITLE
Allow anonymous scope

### DIFF
--- a/src/QuickPayClient.cs
+++ b/src/QuickPayClient.cs
@@ -114,7 +114,7 @@ namespace QuickPay.SDK
                 BaseAddress = new Uri(baseUrl)
             };
 
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{apiKey}")));
+            if (!string.IsNullOrEmpty(apiKey)) httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{apiKey}")));
             httpClient.DefaultRequestHeaders.Add("Accept-Version", "v10");
             httpClient.DefaultRequestHeaders.Add("Accept", accept ?? "application/json");
             httpClient.DefaultRequestHeaders.Add("User-Agent", "QuickPay SDK .NET Core");


### PR DESCRIPTION
Har tilføjet at authentication header kun angives hvis der er angivet en apiKey - eller er det ikke muligt at lave anonymt request.

Med tilføjelsen kan du lave en klient instans helt uden identifikation:

            var quickPayClient = new QuickPayClient(null, null, null);

og kalde Ping-metoden anonymt (hvilket er QuickPay tillader!).